### PR TITLE
Add 64-bit support

### DIFF
--- a/RCSwitch.cpp
+++ b/RCSwitch.cpp
@@ -34,7 +34,7 @@
 
 #include "RCSwitch.h"
 
-unsigned long RCSwitch::nReceivedValue = NULL;
+unsigned long long RCSwitch::nReceivedValue = NULL;
 unsigned int RCSwitch::nReceivedBitlength = 0;
 unsigned int RCSwitch::nReceivedDelay = 0;
 unsigned int RCSwitch::nReceivedProtocol = 0;
@@ -322,7 +322,7 @@ void RCSwitch::sendTriState(char* sCodeWord) {
   }
 }
 
-void RCSwitch::send(unsigned long Code, unsigned int length) {
+void RCSwitch::send(unsigned long long Code, unsigned int length) {
   this->send( this->dec2binWzerofill(Code, length) );
 }
 
@@ -472,7 +472,7 @@ void RCSwitch::resetAvailable() {
   RCSwitch::nReceivedValue = NULL;
 }
 
-unsigned long RCSwitch::getReceivedValue() {
+unsigned long long RCSwitch::getReceivedValue() {
     return RCSwitch::nReceivedValue;
 }
 
@@ -497,7 +497,7 @@ unsigned int* RCSwitch::getReceivedRawdata() {
  */
 bool RCSwitch::receiveProtocol1(unsigned int changeCount){
     
-	  unsigned long code = 0;
+	  unsigned long long code = 0;
       unsigned long delay = RCSwitch::timings[0] / 31;
       unsigned long delayTolerance = delay * RCSwitch::nReceiveTolerance * 0.01;    
 
@@ -533,7 +533,7 @@ bool RCSwitch::receiveProtocol1(unsigned int changeCount){
 
 bool RCSwitch::receiveProtocol2(unsigned int changeCount){
     
-	  unsigned long code = 0;
+	  unsigned long long code = 0;
       unsigned long delay = RCSwitch::timings[0] / 10;
       unsigned long delayTolerance = delay * RCSwitch::nReceiveTolerance * 0.01;    
 
@@ -604,18 +604,18 @@ void RCSwitch::handleInterrupt() {
 /**
   * Turns a decimal value to its binary representation
   */
-char* RCSwitch::dec2binWzerofill(unsigned long Dec, unsigned int bitLength){
+char* RCSwitch::dec2binWzerofill(unsigned long long Dec, unsigned int bitLength){
   static char bin[64];
   unsigned int i=0;
 
   while (Dec > 0) {
-    bin[32+i++] = ((Dec & 1) > 0) ? '1' : '0';
+    bin[64+i++] = ((Dec & 1) > 0) ? '1' : '0';
     Dec = Dec >> 1;
   }
 
   for (unsigned int j = 0; j< bitLength; j++) {
     if (j >= bitLength - i) {
-      bin[j] = bin[ 31 + i - (j - (bitLength - i)) ];
+      bin[j] = bin[ 63 + i - (j - (bitLength - i)) ];
     }else {
       bin[j] = '0';
     }

--- a/RCSwitch.h
+++ b/RCSwitch.h
@@ -54,8 +54,8 @@ typedef uint8_t byte;
 
 
 // Number of maximum High/Low changes per packet.
-// We can handle up to (unsigned long) => 32 bit * 2 H/L changes per bit + 2 for sync
-#define RCSWITCH_MAX_CHANGES 67
+// We can handle up to (unsigned long long) => 64 bit * 2 H/L changes per bit + 2 for sync
+#define RCSWITCH_MAX_CHANGES 131
 
 
 class RCSwitch {
@@ -71,7 +71,7 @@ class RCSwitch {
     void switchOff(char sFamily, int nGroup, int nDevice);
 
     void sendTriState(char* Code);
-    void send(unsigned long Code, unsigned int length);
+    void send(unsigned long long Code, unsigned int length);
     void send(char* Code);
     
     void enableReceive(int interrupt);
@@ -80,7 +80,7 @@ class RCSwitch {
     bool available();
 	void resetAvailable();
 	
-    unsigned long getReceivedValue();
+    unsigned long long getReceivedValue();
     unsigned int getReceivedBitlength();
     unsigned int getReceivedDelay();
 	unsigned int getReceivedProtocol();
@@ -94,7 +94,7 @@ class RCSwitch {
 	void setProtocol(int nProtocol);
 	void setProtocol(int nProtocol, int nPulseLength);
   
-    static char* dec2binWzerofill(unsigned long dec, unsigned int length);
+    static char* dec2binWzerofill(unsigned long long dec, unsigned int length);
 
   private:
     char* getCodeWordB(int nGroupNumber, int nSwitchNumber, boolean bStatus);
@@ -118,7 +118,7 @@ class RCSwitch {
 	char nProtocol;
 
 	static int nReceiveTolerance;
-    static unsigned long nReceivedValue;
+    static unsigned long long nReceivedValue;
     static unsigned int nReceivedBitlength;
 	static unsigned int nReceivedDelay;
 	static unsigned int nReceivedProtocol;

--- a/RFSniffer.cpp
+++ b/RFSniffer.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[]) {
     while(1) {
 
         if (mySwitch.available()) {
-            int value = mySwitch.getReceivedValue();
+            unsigned long long value = mySwitch.getReceivedValue();
 
             if (value == 0) {
                 printf("Unknown encoding\n");

--- a/send.cpp
+++ b/send.cpp
@@ -35,7 +35,7 @@
 #include <string>
 #include <cstring>
 
-extern "C" int send(int switches[], int num_switches, int iterations = 3,
+extern "C" int send(unsigned long long switches[], int num_switches, int iterations = 3,
                     int pin = 17, int pulseLength = 190, int bitLength = 24){
     // Have to use the BCM pin instead of wiringPi pin (e.g. 17 instead of 0)
     // if using wiringPiSetupGpio() or wiringPiSetupSys(). See:
@@ -124,9 +124,9 @@ int main(int argc, char *argv[]) {
     // either the command line via main() or ctypes from python and expect
     // the same number of args
     int num_switches = argc - 1;
-    int switches[num_switches];
+    unsigned long long switches[num_switches];
     for (int i=0; i<num_switches; i++) {
-        switches[i] = std::stoi(argv[i+1]);
+        switches[i] = std::stoll(argv[i+1]);
     }
 
     // Set scheduling if program is run directly from command line. Returning


### PR DESCRIPTION
Hi,

I had some issues using this project with a switch that sent codes above 2^31 (ie above the value of a signed 32-bit integer). The receiver always seems to show the most significant bit as zero. That is, if I receive a value of 2147483649 I get the following:

```
Decimal: 1
Bit length: 32
Pulse length: 260
Binary: 00000000000000000000000000000001
```

But I expect to see this:
```
Decimal: 2147483649
Bit length: 32
Pulse length: 260
Binary: 10000000000000000000000000000001
```

That is likely a bug somewhere in `RCSwitch`, but I couldn't figure out exactly where. Additionally, `stoi` in the sender doesn't permit sending values above 2^32 either.

So to "fix" it, I increased the size to 64 bits (unsigned long long) and replaced the call to `stoi` with `stoull`. It has the exact same issue at values above 2^63 now, but at least that's a far smaller number of devices. It might be fixed upstream, so perhaps just pulling a newer version of `RCSwitch` would help.

That said, 64-bit support is probably worth keeping; I believe some devices out there use >32bit codes.